### PR TITLE
Correct camera recover logic

### DIFF
--- a/NineChronicles.Mods.PVEHelper/PVEHelperPlugin.cs
+++ b/NineChronicles.Mods.PVEHelper/PVEHelperPlugin.cs
@@ -190,9 +190,9 @@ namespace NineChronicles.Mods.PVEHelper
 
         private void DisableEventSystem()
         {
-            _mainCamera = Camera.main;
-            if (_mainCamera)
+            if (_mainCamera is null)
             {
+                _mainCamera = Camera.main;
                 _mainCameraBackgroundColor = _mainCamera.backgroundColor;
                 _mainCameraCullingMask = _mainCamera.cullingMask;
                 _mainCamera.backgroundColor = Color.white;


### PR DESCRIPTION
Now, it cannot return to the main page when pressing `Space` twice because the `_mainCameraBackgroundColor`, `_mainCameraCullingMask` is overwritten with the white color.