### PR TITLE
Avoid to hide item description

### DIFF
--- a/NineChronicles.Mods.PVEHelper/GUIs/InventoryGUI.cs
+++ b/NineChronicles.Mods.PVEHelper/GUIs/InventoryGUI.cs
@@ -48,7 +48,8 @@ namespace NineChronicles.Mods.PVEHelper.GUIs
         // Styles
         private readonly GUIStyle _toolTipStyle = new GUIStyle(GUI.skin.box)
         {
-            normal = { background = ColorTexturePool.Get(new Color(0.1f, 0.1f, 0.1f, 1.0f)) }
+            normal = { background = ColorTexturePool.Get(new Color(0.1f, 0.1f, 0.1f, 1.0f)) },
+            wordWrap = true,
         };
         // ~Styles
 


### PR DESCRIPTION
This pull request is continued from #33 PR. The PR missed to apply `wordWrap = true` for tooltips. This pull request does it.