### PR TITLE
9CAPI Support for Arena Simulation

### DIFF
--- a/NineChronicles.Mods.Athena/AthenaPlugin.cs
+++ b/NineChronicles.Mods.Athena/AthenaPlugin.cs
@@ -212,6 +212,7 @@ namespace NineChronicles.Mods.Athena
                     ("ItemSlots", CreateItemSlotsGUI),
                     ("Adventure", () => new AdventureGUI(UserDataManager.GetItemSlotsCache(BattleType.Adventure))),
                     ("Arena", CreateArenaGUI),
+                    ("Arena-9CAPI", CreateArenaGUI9CAPI),
                     ("Create", CreateItemCreationGUI),
                     ("Enhancement", () => new EnhancementGUI(_modInventoryManager, GetOrCreateInventoryGUI())),
                 }, DisableModeGUI);
@@ -284,6 +285,12 @@ namespace NineChronicles.Mods.Athena
             return new ArenaGUI(
                 UserDataManager.GetItemSlotsCache(BattleType.Arena),
                 _abilityRankingResponse);
+        }
+        private IGUI CreateArenaGUI9CAPI()
+        {
+            return new ArenaGUI(
+                UserDataManager.GetItemSlotsCache(BattleType.Arena),
+                _abilityRankingResponse, false);
         }
 
         private IGUI CreateItemCreationGUI()

--- a/NineChronicles.Mods.Athena/GUIs/ArenaGUI.cs
+++ b/NineChronicles.Mods.Athena/GUIs/ArenaGUI.cs
@@ -123,7 +123,7 @@ namespace NineChronicles.Mods.Athena.GUIs
                 OnSlotSelected += async avatarInfo =>
                 {
                     bool heimdall = false;
-                    if(Game.instance.CurrentPlanetId.Value.ToString() == "0x000000000001")
+                    if(Game.instance.CurrentPlanetId.ToString() == Nekoyume.Multiplanetary.PlanetId.Heimdall.ToString())
                         heimdall = true;
 
                     try

--- a/NineChronicles.Mods.Athena/GUIs/ArenaGUI.cs
+++ b/NineChronicles.Mods.Athena/GUIs/ArenaGUI.cs
@@ -60,10 +60,10 @@ namespace NineChronicles.Mods.Athena.GUIs
         public ArenaGUI(IEnumerable<Equipment> equippedEquipments, AbilityRankingResponse apiResponse, bool LocalSimulation = true)
         {
             _arenaLayoutRect = new Rect(
-            100,
-            100,
-            GUIToolbox.ScreenWidthReference - 200,
-            GUIToolbox.ScreenHeightReference - 100);
+                100,
+                100,
+                GUIToolbox.ScreenWidthReference - 200,
+                GUIToolbox.ScreenHeightReference - 100);
 
             if (apiResponse != null)
             {

--- a/NineChronicles.Mods.Athena/NineChronicles.Mods.Athena.csproj
+++ b/NineChronicles.Mods.Athena/NineChronicles.Mods.Athena.csproj
@@ -9,6 +9,10 @@
   <Import Project="..\.env.xml"/>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NineChronicles.Modules.BlockSimulation\NineChronicles.Modules.BlockSimulation.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds the ability to have online simulation without having to rely on local pc resources.
As long 9CAPI Node is up-to-date, users can also continue simulating without requiring an update on athena regarding new combat logic.